### PR TITLE
Fix capitalization in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Official PyTorch codebase for I-JEPA (the **Image-based Joint-Embedding Predicti
 
 ## Method
 I-JEPA is a method for self-supervised learning. At a high level, I-JEPA predicts the representations of part of an image from the representations of other parts of the same image. Notably, this approach learns semantic image features:
-1. without relying on pre-specified invariances to hand-crafted data transformations, which tend to be biased for particular downstream tasks,
-2. and without having the model fill in pixel-level details, which tend to result in learning less semantically meaningful representations.
+1. Without relying on pre-specified invariances to hand-crafted data transformations, which tend to be biased for particular downstream tasks,
+2. And without having the model fill in pixel-level details, which tend to result in learning less semantically meaningful representations.
 
 ![ijepa](https://github.com/facebookresearch/ijepa/assets/7530871/dbad94ab-ac35-433b-8b4c-ca227886d311)
 


### PR DESCRIPTION
I noticed a minor capitalization issue in the README.md file. This PR aims to fix the capitalization for better readability and adherence to conventional writing style.

### Changes Made:

- Capitalized the first letter of each sentence in the following sections:
    - Without relying on pre-specified invariances to hand-crafted data transformations, which tend to be biased for particular downstream tasks.
    - And without having the model fill in pixel-level details, which tend to result in learning less semantically meaningful representations.