### PR TITLE
multiblock mask collator now samples masks including last row and column

### DIFF
--- a/src/masks/multiblock.py
+++ b/src/masks/multiblock.py
@@ -86,8 +86,8 @@ class MaskCollator(object):
         valid_mask = False
         while not valid_mask:
             # -- Sample block top-left corner
-            top = torch.randint(0, self.height - h, (1,))
-            left = torch.randint(0, self.width - w, (1,))
+            top = torch.randint(0, self.height - h + 1, (1,))
+            left = torch.randint(0, self.width - w + 1, (1,))
             mask = torch.zeros((self.height, self.width), dtype=torch.int32)
             mask[top:top+h, left:left+w] = 1
             # -- Constrain mask to a set of acceptable regions


### PR DESCRIPTION
Previously multiblock mask position sampler used the line torch.randint(0, self.height - h, (1,))... , however since randint is exclusive of the upper bound self.height - h, and similarly self.width - w is never sampled meaning the last row and column of image patches is never used for maksing. This is fixed by adding one to the upper bound.