### PR TITLE
Corrected max value of multi-block mask position range.

### DIFF
--- a/src/masks/multiblock.py
+++ b/src/masks/multiblock.py
@@ -86,8 +86,8 @@ class MaskCollator(object):
         valid_mask = False
         while not valid_mask:
             # -- Sample block top-left corner
-            top = torch.randint(0, self.height - h, (1,))
-            left = torch.randint(0, self.width - w, (1,))
+            top = torch.randint(0, self.height - h + 1, (1,))
+            left = torch.randint(0, self.width - w + 1, (1,))
             mask = torch.zeros((self.height, self.width), dtype=torch.int32)
             mask[top:top+h, left:left+w] = 1
             # -- Constrain mask to a set of acceptable regions


### PR DESCRIPTION
The upper bound for the positioning sample range of the multi-block mask collator was incorrect.

Added '+1' such that far-right column and bottom row of patches can be masked.